### PR TITLE
only commit, finished, 4/4 passing

### DIFF
--- a/spec/nytimes_spec.rb
+++ b/spec/nytimes_spec.rb
@@ -15,22 +15,25 @@ class Nytimes
       expect(result).to eq("OK")
     end
 
-    xit 'can get copyright' do 
+    it 'can get copyright' do 
       #Using @hash, define a variable called `result` that returns the copyright
+      result = @hash[:copyright]
 
       expect(result).to eq("Copyright (c) 2018 The New York Times Company. All Rights Reserved.")
     end
 
-    xit 'can get array of stories' do 
+    it 'can get array of stories' do 
       #Using @hash, define a variable called `result` that returns the array of stories
+      result = @hash[:results]
   
       expect(result).to be_an_instance_of(Array)
       expect(result.count).to eq(44)
     end
 
-    xit 'can get all stories with subsection of politics' do 
+    it 'can get all stories with subsection of politics' do 
       #Using @hash, define a variable called `result` that returns all stories with subsection of politics.
-  
+      result = @hash[:results].select { |story| story[:subsection] == 'Politics' }
+
       expect(result).to be_an_instance_of(Array)
       expect(result.count).to eq(6)
       expect(result.first[:title]).to eq("Congressional G.O.P. Agenda Quietly Falls Into Place Even as Trump Steals the Spotlight")


### PR DESCRIPTION
used status, result, copyright to find main 3, last one took longer.

Needed to selete the results with .select, then try and **filter** the stories subsections that matched the word "Politics". Do not feel this was the most dynamic way to go about it becasue i only filter based on subsection, so if that ever changed to section or any other word, itd fail again. but it works 4/4 passing tests

